### PR TITLE
Better types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3186,6 +3186,7 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
+        "fsevents": "~2.3.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -6420,6 +6421,7 @@
         "minimist": "^1.2.5",
         "neo-async": "^2.6.0",
         "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4",
         "wordwrap": "^1.0.0"
       },
       "bin": {
@@ -14755,6 +14757,7 @@
         "jest-resolve": "^25.5.1",
         "jest-util": "^25.5.0",
         "jest-worker": "^25.5.0",
+        "node-notifier": "^6.0.0",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^3.1.0",
@@ -15251,6 +15254,7 @@
         "@types/graceful-fs": "^4.1.2",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
+        "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.4",
         "jest-serializer": "^25.5.0",
         "jest-util": "^25.5.0",
@@ -16403,8 +16407,10 @@
       "integrity": "sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==",
       "dev": true,
       "dependencies": {
+        "chokidar": "^3.4.1",
         "graceful-fs": "^4.1.2",
-        "neo-async": "^2.5.0"
+        "neo-async": "^2.5.0",
+        "watchpack-chokidar2": "^2.0.1"
       },
       "optionalDependencies": {
         "chokidar": "^3.4.1",
@@ -16442,6 +16448,7 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
+        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -10,3 +10,9 @@
 export interface LooseObject<T> {
   [key: string]: T;
 }
+
+/** Type alias for Variable */
+export type Variable = string;
+
+/** Type alias for the current domain */
+export type CurrentDomain<T> = LooseObject<T>;

--- a/src/min_conflicts.ts
+++ b/src/min_conflicts.ts
@@ -1,25 +1,25 @@
 /* Min-conflicts hill-climbing search for CSPs functions */
 
 import { CSP } from "./csp";
-import { LooseObject } from "./interfaces";
+import { CurrentDomain, Variable } from "./interfaces";
 import { argmin_random_tie, random_choice } from "./utils";
 
 /**
  * Solve a CSP by stochastic hill-climbing on the number of conflicts.
  *
- * @param  {CSP<T>} aCSP
+ * @param  {CSP<TAttributes>} aCSP
  * @param  {number=100000} max_steps
- * @returns LooseObject
+ * @returns CurrentDomain<TAttributes> | undefined
  */
-export const min_conflicts = <T extends string>(
-  aCSP: CSP<T>,
+export const min_conflicts = <TAttributes extends object>(
+  aCSP: CSP<TAttributes>,
   max_steps: number = 100000,
-): LooseObject<T[]> | undefined => {
+): CurrentDomain<TAttributes> | undefined => {
   // Generate a complete assignment for all variables (probably with conflicts)
-  let current: LooseObject<T[]> = {};
+  let current: CurrentDomain<TAttributes> = {};
   aCSP.variables.forEach(variable => {
-    const val = min_conflicts_value<T>(aCSP, variable as T, current);
-    aCSP.assign(variable as T, val, current);
+    const val = min_conflicts_value<TAttributes>(aCSP, variable, current);
+    aCSP.assign(variable, val, current);
   });
 
   // Now repeatedly choose a random conflicted variable and change it
@@ -33,6 +33,7 @@ export const min_conflicts = <T extends string>(
     aCSP.assign(variable, val, current);
   }
   // If no solution can be found.
+  // TODO: update this to return the schedule with conflicts.
   return undefined;
 };
 
@@ -40,16 +41,16 @@ export const min_conflicts = <T extends string>(
  * Return the value that will give var the least number of conflicts.
  * If there is a tie, choose at random.
  *
- * @param  {CSP<T>} aCSP
- * @param  {T} variable
- * @param  {LooseObject<T[]>} current
- * @returns T
+ * @param  {CSP<TAttributes>} aCSP
+ * @param  {Variable} variable
+ * @param  {CurrentDomain<TAttributes>} current
+ * @returns TAttributes
  */
-export const min_conflicts_value = <T extends string>(
-  aCSP: CSP<T>,
-  variable: T,
-  current: LooseObject<T[]>,
-): T[] => {
-  const num_conflicts = (val: T[]) => aCSP.nconflicts(variable, val, current);
+export const min_conflicts_value = <TAttributes extends object>(
+  aCSP: CSP<TAttributes>,
+  variable: Variable,
+  current: CurrentDomain<TAttributes>,
+): TAttributes => {
+  const num_conflicts = (val: TAttributes) => aCSP.nconflicts(variable, val, current);
   return argmin_random_tie(aCSP.domains[variable], num_conflicts);
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -29,10 +29,10 @@ export const shuffle_array = (arr: any[]): any[] => {
 /**
  * Returns the paramter
  *
- * @param  {any} val
- * @returns any
+ * @param  {T} val
+ * @returns T
  */
-export const identity = (val: any): any => val;
+export const identity = <T>(val: T): T => val;
 
 /**
  * Return a minimum element of seq; break ties at random.

--- a/test/csp.test.ts
+++ b/test/csp.test.ts
@@ -1,12 +1,12 @@
 import { CSP } from "../src";
-import { LooseObject } from "../src/interfaces";
-import { constraints, domains, neighbors, variables } from "./test_helpers";
+import { CurrentDomain } from "../src/interfaces";
+import { ClassAttributes, constraints, domains, neighbors, variables } from "./test_helpers";
 
 // TODO: add a better ESLint Config
 
 describe("csp object instance", () => {
   it("is initialized with four params", () => {
-    const csp = new CSP<string>(variables, domains, neighbors, constraints);
+    const csp = new CSP<ClassAttributes>(variables, domains, neighbors, constraints);
     expect(csp.initial).toEqual([]);
     expect(csp.goal).toEqual(undefined);
 
@@ -35,12 +35,11 @@ describe("csp object instance", () => {
   });
 
   let csp = new CSP(undefined, domains, neighbors, constraints);
-  let assignment: LooseObject<string[]> = {};
+  let assignment: CurrentDomain<ClassAttributes> = {};
   const first_class = variables[0];
-  // # Note: all of the domain values are the same for every variable in this example
+  // Note: all of the domain values are the same for every variable in this example
   const first_valid_attributes = domains[first_class][0];
-  const second_valid_assignments = domains[first_class][1];
-  const tmp_assignment: LooseObject<string[]> = {};
+  const tmp_assignment: CurrentDomain<ClassAttributes> = {};
 
   it("correctly uses CSP.assign() to assign", () => {
     csp.assign(first_class, first_valid_attributes, assignment);
@@ -49,10 +48,12 @@ describe("csp object instance", () => {
     expect(csp.nassigns).toEqual(1);
   });
 
+  const second_valid_assignments = domains[first_class][1];
+
   it("correctly uses CSP.assign() to reassign", () => {
     csp.assign(first_class, second_valid_assignments, assignment);
     tmp_assignment[first_class] = second_valid_assignments;
-    // # TODO: should this be 1? Can update my class logic.
+    // TODO: should this be 1? Can update my class logic.
     expect(assignment).toEqual(tmp_assignment);
     expect(csp.nassigns).toEqual(2);
   });
@@ -63,20 +64,20 @@ describe("csp object instance", () => {
     expect(csp.nassigns).toEqual(2);
     csp.unassign(first_class, assignment);
     expect(assignment).toEqual({});
-    // # assert aCSP.nassigns == 0 # TODO: Should this be 0 instead of 2?
+    // assert aCSP.nassigns == 0 # TODO: Should this be 0 instead of 2?
     expect(csp.nassigns).toEqual(2);
 
     // remove a class that isn't in the schedule
     csp.assign(third_class, first_valid_attributes, assignment);
     csp.unassign(second_class, assignment);
-    const tmp_assignment: LooseObject<string[]> = {};
+    const tmp_assignment: CurrentDomain<ClassAttributes> = {};
     tmp_assignment[third_class] = first_valid_attributes;
     expect(assignment).toEqual(tmp_assignment);
     expect(csp.nassigns).toEqual(3);
 
     csp.unassign(third_class, assignment);
     expect(assignment).toEqual({});
-    // # TODO: should this be 0?
+    // TODO: should this be 0?
     expect(csp.nassigns).toEqual(3);
   });
 
@@ -114,7 +115,7 @@ describe("csp object instance", () => {
     });
     expect(csp.conflicted_vars(assignment)).toEqual(variables);
     expect(csp.conflicted_vars(assignment).length).toEqual(4);
-    // # change one of the conflicts
+    // change one of the conflicts
     assignment[first_class] = sixth_valid_attributes;
     const variables_copy = [...variables];
     var index = variables.indexOf(first_class);
@@ -125,7 +126,7 @@ describe("csp object instance", () => {
     expect(csp.conflicted_vars(assignment)).toEqual(variables_copy);
     expect(csp.conflicted_vars(assignment).length).toEqual(3);
 
-    // # change back to conflict
+    // change back to conflict
     assignment[first_class] = second_valid_assignments;
     expect(csp.conflicted_vars(assignment)).toEqual(variables);
     expect(csp.conflicted_vars(assignment).length).toEqual(4);

--- a/test/min_conflicts.test.ts
+++ b/test/min_conflicts.test.ts
@@ -1,7 +1,7 @@
 import seedrandom from "seedrandom";
 import { CSP, min_conflicts, min_conflicts_value } from "../src";
 import { argmin_random_tie, identity, random_choice, shuffle_array } from "../src/utils";
-import { constraints, domains, neighbors, variables } from "./test_helpers";
+import { ClassAttributes, constraints, domains, neighbors, variables } from "./test_helpers";
 // NOTE: changing the LOC in this file breaks tests with random.
 seedrandom("seed", { global: true });
 
@@ -12,49 +12,49 @@ describe("min_conflicts functions", () => {
   });
 
   it("correctly implements shuffle_array()", () => {
-    expect(shuffle_array([1, 2, 3, 4])).toEqual([3, 4, 1, 2]);
+    expect(shuffle_array([1, 2, 3, 4])).toEqual([4, 3, 2, 1]);
   });
 
   it("correctly implements random_choice()", () => {
     expect(random_choice([1, 2, 3, 4])).toEqual(4);
   });
 
-  it("correctly implements argmin_random_tie()", () => {
+  it("correctly implements argmin_random_tie() using identity function", () => {
     expect(argmin_random_tie([1, 2, 3, 4])).toEqual(1);
     expect(argmin_random_tie([10, 20, -1, 4])).toEqual(-1);
   });
 
-  // # Generate the CSP values.
-  const aCSP = new CSP<string>(variables, domains, neighbors, constraints);
+  // Generate the CSP values.
+  const aCSP = new CSP<ClassAttributes>(variables, domains, neighbors, constraints);
 
-  // # set up assignments for classes.
+  // set up assignments for classes.
   const assignment = {};
   const [first_class, second_class, third_class, fourth_class] = variables;
 
-  // # Note: for the testing, the domains are the same for every class.
+  // Note: for the testing, the domains are the same for every class.
   const [first_domain_attrs, second_domain_attrs] = domains[first_class];
   aCSP.assign(first_class, first_domain_attrs, assignment);
   aCSP.assign(second_class, second_domain_attrs, assignment);
   aCSP.assign(third_class, second_domain_attrs, assignment);
 
   it("correctly implements min_conflicts_value()", () => {
-    const res = ["mwf900", "nh253", "adams"];
+    const res: ClassAttributes = { time: "mwf900", room: "sb382", faculty: "norman" };
     expect(min_conflicts_value(aCSP, fourth_class, assignment)).toEqual(res);
     aCSP.assign(fourth_class, res, assignment);
     expect(assignment).toEqual({
-      cs108: ["mwf800", "nh253", "norman"],
-      cs112: ["mwf800", "nh253", "vanderlinden"],
-      cs212: ["mwf800", "nh253", "vanderlinden"],
+      cs108: { time: "mwf800", room: "nh253", faculty: "norman" },
+      cs112: { time: "mwf800", room: "nh253", faculty: "vanderlinden" },
+      cs212: { time: "mwf800", room: "nh253", faculty: "vanderlinden" },
       cs214: res,
     });
   });
 
   it("correctly implements min_conflicts()", () => {
     expect(min_conflicts(aCSP)).toEqual({
-      cs108: ["mwf800", "nh253", "norman"],
-      cs112: ["mwf900", "sb382", "vanderlinden"],
-      cs212: ["mwf800", "sb382", "vanderlinden"],
-      cs214: ["mwf900", "nh253", "adams"],
+      cs108: { time: "mwf900", room: "nh253", faculty: "adams" },
+      cs112: { time: "mwf900", room: "sb382", faculty: "vanderlinden" },
+      cs212: { time: "mwf800", room: "sb382", faculty: "vanderlinden" },
+      cs214: { time: "mwf800", room: "nh253", faculty: "adams" },
     });
   });
 });

--- a/test/test_helpers.ts
+++ b/test/test_helpers.ts
@@ -62,7 +62,7 @@ export const constraints = (
   }
 
   // Check to make sure faculty is not teaching at the same time
-  if (c1Attributes.faculty === c2Attributes.faculty && c1Attributes.time === c2Attributes.time) {
+  if (c1Attributes.time === c2Attributes.time && c1Attributes.faculty === c2Attributes.faculty) {
     return false;
   }
 


### PR DESCRIPTION
This PR separates the Variable type from the Attribute type. This was an oversight. The two should not be related.

I opted to make the variable a string since it is commonly used as an accessor for objects. I could see in the future, the variable is a complex object, and one of the fields is a string used as its identifier. 

THis PR makes variable attributes an object rather than a tuple which makes writing constraints easier. 